### PR TITLE
Fix 'make install' on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,12 @@ clean: setup.data
 	ocaml setup.ml -clean
 
 install: build
-	install -D -m 755 main.native ${BINDIR}/vhd-tool || echo "Failed to install vhd-tool"
-	install -D -m 755 sparse_dd.native ${LIBEXECDIR}/sparse_dd || echo "Failed to install sparse_dd"
-	install -D -m 644 src/sparse_dd.conf ${ETCDIR}/sparse_dd.conf || echo "Failed to install sparse_dd.conf"
+	mkdir -p ${BINDIR}
+	install -m 755 main.native ${BINDIR}/vhd-tool || echo "Failed to install vhd-tool"
+	mkdir -p ${LIBEXECDIR}
+	install -m 755 sparse_dd.native ${LIBEXECDIR}/sparse_dd || echo "Failed to install sparse_dd"
+	mkdir -p ${ETCDIR}
+	install -m 644 src/sparse_dd.conf ${ETCDIR}/sparse_dd.conf || echo "Failed to install sparse_dd.conf"
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
We decompose 'install -D' into 'mkdir -p' and 'install'

Signed-off-by: David Scott dave.scott@citrix.com
