### PR TITLE
Disable opam lint in CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - PACKAGE="vhd-tool" OCAML_VERSION=4.01
-  - PACKAGE="vhd-tool" OCAML_VERSION=latest
+  global:
+    - PACKAGE=vhd-tool OPAM_LINT=false
+  matrix:
+    - OCAML_VERSION=4.01
+    - OCAML_VERSION=latest


### PR DESCRIPTION
This is blocking CI when using ocaml/ocaml-ci-scripts for builds on Travis-ci.

Obviously a better fix would be to fix the OPAM file but in lieu of that, this would unblock testing.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
